### PR TITLE
Check for 'working' status in JS, along with 'queued'

### DIFF
--- a/app/assets/javascripts/resque_poll/poller.coffee
+++ b/app/assets/javascripts/resque_poll/poller.coffee
@@ -11,7 +11,7 @@ class ResquePoller
   _poll: => $.getJSON @url, (resp) => @_handleResponse(resp)
 
   _handleResponse: (resp) ->
-    return if resp.status is 'queued'
+    return if resp.status is 'queued' || resp.status is 'working'
     clearInterval @intervalID if @intervalID
     switch resp.status
       when 'completed'

--- a/app/assets/javascripts/resque_poll/poller.coffee
+++ b/app/assets/javascripts/resque_poll/poller.coffee
@@ -11,7 +11,7 @@ class ResquePoller
   _poll: => $.getJSON @url, (resp) => @_handleResponse(resp)
 
   _handleResponse: (resp) ->
-    return if resp.status is 'queued' || resp.status is 'working'
+    return if (resp.status is 'queued' || resp.status is 'working')
     clearInterval @intervalID if @intervalID
     switch resp.status
       when 'completed'


### PR DESCRIPTION
The JS poller stops polling when the status transitions from 'queued' to 'working'. This change allows it to continue polling until the 'completed' or failing status is returned.
