### PR TITLE
remove sslrequirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,13 @@ gemspec
 gem "coffee-rails"
 gem "jquery-rails"
 gem "resque-status"
+gem "strong_parameters"
 
 group :test do
   gem "capybara"
   gem "capybara-webkit"
   gem "ejs"
-  gem "konacha"
-  gem "konacha-chai-matchers"
-  gem "sinon-chai-rails"
+  # gem "konacha"
+  # gem "konacha-chai-matchers"
+  # gem "sinon-chai-rails"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,12 @@ gemspec
 gem "coffee-rails"
 gem "jquery-rails"
 gem "resque-status"
-gem "strong_parameters"
 
 group :test do
   gem "capybara"
   gem "capybara-webkit"
   gem "ejs"
-  # gem "konacha"
-  # gem "konacha-chai-matchers"
-  # gem "sinon-chai-rails"
+  gem "konacha"
+  gem "konacha-chai-matchers"
+  gem "sinon-chai-rails"
 end

--- a/app/controllers/resque_poll/application_controller.rb
+++ b/app/controllers/resque_poll/application_controller.rb
@@ -1,5 +1,4 @@
 module ResquePoll
   class ApplicationController < ActionController::Base
-    include ::SslRequirement
   end
 end

--- a/app/controllers/resque_poll/jobs_controller.rb
+++ b/app/controllers/resque_poll/jobs_controller.rb
@@ -1,8 +1,6 @@
 class ResquePoll::JobsController < ResquePoll::ApplicationController
   respond_to :json
 
-  ssl_allowed :show
-
   def show
     status = Resque::Plugins::Status::Hash.get(params.require(:id))
     if status.nil?

--- a/lib/resque-poll.rb
+++ b/lib/resque-poll.rb
@@ -1,5 +1,4 @@
 require "resque_poll/engine"
-require "ssl_requirement"
 
 module ResquePoll
 end

--- a/resque-poll.gemspec
+++ b/resque-poll.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "bartt-ssl_requirement", "~> 1.4"
   s.add_dependency "rails", "~> 4.0.0"
   s.add_dependency "resque-status", "~> 0.4"
 

--- a/resque-poll.gemspec
+++ b/resque-poll.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 3.2.15"
+  s.add_dependency "rails", "~> 4.0.0"
   s.add_dependency "resque-status", "~> 0.5"
 
   s.add_development_dependency "fakeredis"
   s.add_development_dependency "pry"
-  # s.add_development_dependency "rspec-its", '~> 1.1.0'
-  s.add_development_dependency "rspec-rails", "~> 2.14"
+  s.add_development_dependency "rspec-its", '~> 1.1.0'
+  s.add_development_dependency "rspec-rails", '~> 3.2.1'
   s.add_development_dependency "sqlite3"
 end

--- a/resque-poll.gemspec
+++ b/resque-poll.gemspec
@@ -13,12 +13,12 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 4.0.0"
-  s.add_dependency "resque-status", "~> 0.4"
+  s.add_dependency "rails", "~> 3.2.15"
+  s.add_dependency "resque-status", "~> 0.5"
 
   s.add_development_dependency "fakeredis"
   s.add_development_dependency "pry"
-  s.add_development_dependency "rspec-its", '~> 1.1.0'
-  s.add_development_dependency "rspec-rails", "~> 3.2.1"
+  # s.add_development_dependency "rspec-its", '~> 1.1.0'
+  s.add_development_dependency "rspec-rails", "~> 2.14"
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
bartt-sslrequirement is not compatible with Rails 4 or versions of Ruby < 2. See [bartt-ssl_requirement readme](https://github.com/bartt/ssl_requirement)

It looks like since this is a project that includes Rails 3, we should be using [force_ssl](http://apidock.com/rails/ActionController/ForceSSL/ClassMethods/force_ssl) for any methods that have to be in SSL (`ssl_required` in bartt-ssl_requirement).

It also doesn't look like we're using it here in any way here besides `ssl_allowed :show` in jobs_controller.
